### PR TITLE
Make sure the expression tester attempts to parse the whole string

### DIFF
--- a/src/test/scala/wolfendale/nunjucks/expression/ExpressionTester.scala
+++ b/src/test/scala/wolfendale/nunjucks/expression/ExpressionTester.scala
@@ -7,6 +7,10 @@ class ExpressionTester(environment: Environment = new ProvidedEnvironment()) {
 
   def evaluate(expression: String, scope: Value.Obj = Value.Obj.empty): Value = {
     import fastparse._
-    parse(expression, Parser.expression(_)).get.value.eval(Context(environment, Frame(scope)))
+    import SingleLineWhitespace._
+
+    def parser[_: P] = P(Parser.expression ~ End)
+
+    parse(expression, parser(_)).get.value.eval(Context(environment, Frame(scope)))
   }
 }


### PR DESCRIPTION
This isn't really a bug but it may help us catch some edge cases in tests.