### PR TITLE
Add a toString for Number class

### DIFF
--- a/src/main/scala/wolfendale/nunjucks/expression/runtime/Value.scala
+++ b/src/main/scala/wolfendale/nunjucks/expression/runtime/Value.scala
@@ -433,6 +433,8 @@ object Value {
     override def toStr: Str =
       Str(if (value.isWhole) value.toLong.toString else value.toString)
 
+    override def toString: String = toStr.toString
+
     override def toBool: Bool =
       if (value == 0) False else True
 
@@ -453,6 +455,8 @@ object Value {
 
     override def toStr: Str =
       this
+
+    override def toString: String = value
 
     override def toBool: Bool =
       if (value.isEmpty) False else True

--- a/src/test/scala/wolfendale/nunjucks/equivalence/CompilerSpec.scala
+++ b/src/test/scala/wolfendale/nunjucks/equivalence/CompilerSpec.scala
@@ -505,6 +505,14 @@ class CompilerSpec extends FreeSpec with MustMatchers with OptionValues {
     environment.render("{{ -5 }}") mustEqual "-5"
   }
 
+  "should compile arrays" in {
+    environment.render("{{ [1,2,3] }}") mustEqual "1,2,3"
+  }
+
+  "should compile arrays of functions" in {
+    environment.render("{{ [1 + 1, 2 * 2, 3 ** 3] }}") mustEqual "2,4,27"
+  }
+
   "should compile comparison operators" in {
 
     environment.render("{% if 3 < 4 %}yes{% endif %}") mustEqual "yes"


### PR DESCRIPTION
Hardly seems worth it but at the stage where you want to enforce a real string we will have evaluated all the Str classes. Any other way you'ld have to reimplement mkString for Arr. 