### PR TITLE
Fix parse order of comparison operators

### DIFF
--- a/src/main/scala/wolfendale/nunjucks/expression/Parser.scala
+++ b/src/main/scala/wolfendale/nunjucks/expression/Parser.scala
@@ -98,7 +98,7 @@ object Parser {
 
       def notIn = P("not " ~ "in").map(_ => AST.BinaryOperator.NotIn)
 
-      binop(addition, P(gt | gte | lt | lte | in | notIn))
+      binop(addition, P(gte | gt | lte | lt | in | notIn))
     }
 
     def equality = {
@@ -110,7 +110,7 @@ object Parser {
 
       def sneq = P("!==").map(_ => AST.BinaryOperator.StrictInequality)
 
-      binop(comparison, P(eq | neq | seq | sneq))
+      binop(comparison, P(sneq | seq | neq | eq))
     }
 
     def and = {


### PR DESCRIPTION
When rewriting the binary operator parsing, I mixed up the order of the operators which meant it would try to parse things like `==` before `===` and therefore always succeed.