### PR TITLE
Fix imports and macros

### DIFF
--- a/src/main/scala/wolfendale/nunjucks/Environment.scala
+++ b/src/main/scala/wolfendale/nunjucks/Environment.scala
@@ -17,9 +17,12 @@ class Environment(loaders: NonEmptyChain[Loader]) {
     renderTemplate(path, Value.Obj.empty)
 
   def renderTemplate(path: String, scope: Value.Obj): Option[String] = {
-    val context = Context(this)
-      .variables.set(scope.values.toSeq)
-    resolveAndLoad(path, None).toOption.map(_.template.render.runA(context).value)
+    resolveAndLoad(path, None).toOption.map { resolvedTemplate =>
+      val context = Context(this)
+          .variables.set(scope.values.toSeq)
+          .path.set(Some(resolvedTemplate.path))
+      resolvedTemplate.template.render.runA(context).value
+    }
   }
 
   def render(template: String): String =

--- a/src/main/scala/wolfendale/nunjucks/Environment.scala
+++ b/src/main/scala/wolfendale/nunjucks/Environment.scala
@@ -18,7 +18,7 @@ class Environment(loaders: NonEmptyChain[Loader]) {
 
   def renderTemplate(path: String, scope: Value.Obj): Option[String] = {
     resolveAndLoad(path, None).toOption.map { resolvedTemplate =>
-      val context = Context(this)
+      val context = Context(this, RenderMode.Template)
           .variables.set(scope.values.toSeq)
           .path.set(Some(resolvedTemplate.path))
       resolvedTemplate.template.render.runA(context).value
@@ -31,7 +31,7 @@ class Environment(loaders: NonEmptyChain[Loader]) {
   def render(template: String, scope: Value.Obj): String = {
     // TODO handle errors
     import fastparse._
-    val context = Context(this)
+    val context = Context(this, RenderMode.Template)
       .variables.set(scope.values.toSeq)
     parse(template, TemplateParser.template(_)).get.value.render.runA(context).value
   }

--- a/src/main/scala/wolfendale/nunjucks/Frame.scala
+++ b/src/main/scala/wolfendale/nunjucks/Frame.scala
@@ -15,11 +15,11 @@ sealed abstract class Frame {
         m.set(k, v, resolveUp)
     }
 
-  def value: Value.Obj
-
   def resolve(key: String): Option[Frame]
 
   def isRoot: Boolean
+
+  def values: Map[String, Value]
 }
 
 final case class RootFrame(values: Map[String, Value]) extends Frame {
@@ -29,9 +29,6 @@ final case class RootFrame(values: Map[String, Value]) extends Frame {
 
   override def pop: RootFrame =
     throw new RuntimeException("escaped root scope")
-
-  override def value: Value.Obj =
-    Value.Obj(values)
 
   override def set(key: String, value: Value, resolveUp: Boolean): Frame =
     RootFrame(values + (key -> value))
@@ -68,9 +65,6 @@ final case class ChildFrame(values: Map[String, Value], parent: Frame) extends F
     } else {
       Frame(values + (key -> value), parent)
     }
-
-  override def value: Value.Obj =
-    parent.value merge Value.Obj(values)
 
   override def resolve(key: String): Option[Frame] =
     if (values.get(key).isDefined) Some(this) else parent.resolve(key)

--- a/src/main/scala/wolfendale/nunjucks/expression/syntax/AST.scala
+++ b/src/main/scala/wolfendale/nunjucks/expression/syntax/AST.scala
@@ -73,7 +73,7 @@ object AST {
 
     override def eval: State[Context, Value] =
       State.inspect { context =>
-        context.get(value)
+        context.getFrameOrVariable(value)
       }
   }
 

--- a/src/test/scala/wolfendale/nunjucks/FrameSpec.scala
+++ b/src/test/scala/wolfendale/nunjucks/FrameSpec.scala
@@ -70,35 +70,5 @@ class FrameSpec extends FreeSpec with MustMatchers with OptionValues {
         scope.pop.get("foo") mustEqual Value.Str("rab")
       }
     }
-
-    "value" - {
-
-      "must flatten scopes into an object value" in {
-
-        val result = Frame.empty
-          .set("baz", Value.Str("quux"), resolveUp = false)
-          .push
-          .set("foo", Value.Str("bar"), resolveUp = false)
-
-        result.value mustEqual Value.Obj(
-          "foo" -> Value.Str("bar"),
-          "baz" -> Value.Str("quux")
-        )
-      }
-
-      "must resolve conflicts by preferring the most specific scope" in {
-
-        val result = Frame.empty
-          .set("foo", Value.Str("rab"), resolveUp = false)
-          .set("fork", Value.Str("spoon"), resolveUp = false)
-          .push
-          .set("foo", Value.Str("bar"), resolveUp = false)
-
-        result.value mustEqual Value.Obj(
-          "foo" -> Value.Str("bar"),
-          "fork" -> Value.Str("spoon")
-        )
-      }
-    }
   }
 }

--- a/src/test/scala/wolfendale/nunjucks/expression/ExpressionTester.scala
+++ b/src/test/scala/wolfendale/nunjucks/expression/ExpressionTester.scala
@@ -1,14 +1,14 @@
 package wolfendale.nunjucks.expression
 
 import fastparse._
-import wolfendale.nunjucks.{Context, Environment, Frame, ProvidedEnvironment}
 import wolfendale.nunjucks.expression.runtime.Value
 import wolfendale.nunjucks.expression.syntax.AST
+import wolfendale.nunjucks.{Context, Environment, Frame, ProvidedEnvironment, RenderMode}
 
 class ExpressionTester(environment: Environment = new ProvidedEnvironment()) {
 
   def evaluate(expression: String, scope: Value.Obj = Value.Obj.empty): Value = {
-    ast(expression).get.value.eval.runA(Context(environment, Frame(scope))).value
+    ast(expression).get.value.eval.runA(Context(environment, RenderMode.Template, Frame(scope))).value
   }
 
   def ast(expression: String): Parsed[AST.Expr] = {

--- a/src/test/scala/wolfendale/nunjucks/template/ImportTagSpec.scala
+++ b/src/test/scala/wolfendale/nunjucks/template/ImportTagSpec.scala
@@ -44,6 +44,24 @@ class ImportTagSpec extends FreeSpec with MustMatchers with OptionValues {
 
       env.renderTemplate("test.njk").value mustEqual "undefinedbar"
     }
+
+    "must modify the calling context when an importing with context" in {
+
+      val env = environment
+        .add("import.njk", "{% set foo = 'bar' %}")
+        .add("test.njk", "{% set foo = 'foo' %}{% import 'import.njk' as imp with context %}{{ foo }}{{ imp.foo }}")
+
+      env.renderTemplate("test.njk").value mustEqual "barbar"
+    }
+
+    "must not modify the calling context when importing without context" in {
+
+      val env = environment
+        .add("import.njk", "{% set foo = 'bar' %}")
+        .add("test.njk", "{% set foo = 'foo' %}{% import 'import.njk' as imp without context %}{{ foo }}{{ imp.foo }}")
+
+      env.renderTemplate("test.njk").value mustEqual "foobar"
+    }
   }
 
   "a from tag" - {
@@ -91,6 +109,24 @@ class ImportTagSpec extends FreeSpec with MustMatchers with OptionValues {
         .add("test.njk", "{% from 'import.njk' import foo, bar as baz %}{{ foo }}{{ baz }}")
 
       env.renderTemplate("test.njk").value mustEqual "12"
+    }
+
+    "must modify the calling context when an importing with context" in {
+
+      val env = environment
+        .add("import.njk", "{% set foo = 'bar' %}")
+        .add("test.njk", "{% set foo = 'foo' %}{% from 'import.njk' import foo as bar with context %}{{ foo }}{{ bar }}")
+
+      env.renderTemplate("test.njk").value mustEqual "barbar"
+    }
+
+    "must not modify the calling context when importing without context" in {
+
+      val env = environment
+        .add("import.njk", "{% set foo = 'bar' %}")
+        .add("test.njk", "{% set foo = 'foo' %}{% from 'import.njk' import foo as bar without context %}{{ foo }}{{ bar }}")
+
+      env.renderTemplate("test.njk").value mustEqual "foobar"
     }
   }
 }

--- a/src/test/scala/wolfendale/nunjucks/template/MacroTagSpec.scala
+++ b/src/test/scala/wolfendale/nunjucks/template/MacroTagSpec.scala
@@ -91,6 +91,24 @@ class MacroTagSpec extends FreeSpec with MustMatchers with OptionValues {
       result mustEqual "123456789"
     }
 
+    "must have access to the root template context when imported with context" in {
+
+      val env = environment
+        .add("import.njk", "{% macro foo() %}{{ bar }}{% endmacro %}")
+        .add("test.njk", "{% set bar = 'foo' %}{% import 'import.njk' as imp with context %}{{ imp.foo() }}")
+
+      env.renderTemplate("test.njk").value mustEqual "foo"
+    }
+
+    "must not have access to the root template context when imported without context" in {
+
+      val env = environment
+        .add("import.njk", "{% macro foo() %}{{ bar }}{% endmacro %}")
+        .add("test.njk", "{% set bar = 'foo' %}{% import 'import.njk' as imp %}{{ imp.foo() }}")
+
+      env.renderTemplate("test.njk").value mustEqual ""
+    }
+
     "must locate the right include from a macro call" in {
 
       val environment = new ProvidedEnvironment()

--- a/src/test/scala/wolfendale/nunjucks/template/MacroTagSpec.scala
+++ b/src/test/scala/wolfendale/nunjucks/template/MacroTagSpec.scala
@@ -1,9 +1,9 @@
 package wolfendale.nunjucks.template
 
-import org.scalatest.{FreeSpec, MustMatchers}
+import org.scalatest.{FreeSpec, MustMatchers, OptionValues}
 import wolfendale.nunjucks.ProvidedEnvironment
 
-class MacroTagSpec extends FreeSpec with MustMatchers {
+class MacroTagSpec extends FreeSpec with MustMatchers with OptionValues {
 
   val environment = new ProvidedEnvironment()
 
@@ -89,6 +89,17 @@ class MacroTagSpec extends FreeSpec with MustMatchers {
       val result = environment.render("{% macro fib(num) %}{% if num < 10 %}{{ num }}{{ fib(num + 1) }}{% endif %}{% endmacro %}{{ fib(1) }}")
 
       result mustEqual "123456789"
+    }
+
+    "must locate the right include from a macro call" in {
+
+      val environment = new ProvidedEnvironment()
+        .add("include.njk", "wrong")
+        .add("sub/include.njk", "right")
+        .add("sub/macro.njk", "{% macro foo() %}{% include 'include.njk' %}{% endmacro %}")
+        .add("test.njk", "{% from 'sub/macro.njk' import foo %}{{ foo() }}")
+
+      environment.renderTemplate("test.njk").value mustEqual "right"
     }
   }
 


### PR DESCRIPTION
This fixes all of the equivalence tests that were failing related to macros and template imports (other than a few that also rely on template inheritance)

Added more tests for imports and macros

I really didn't like having to add the `RenderMode` to allow macros to have different behaviour depending on whether they've been imported or not. I'm also pretty unhappy with the code for macros in general. Dealing with them as a purely functional computation has battered my noggin somewhat. I'd definitely love a simpler approach if anyone can think of one.

This also fixes an issue with resource loading that was causing a resource loader test to fail. I've added a simplified version of the failing case to the macro specs. As a side effect the play test project works again!