### PR TITLE
Move filters to the environment instead of context

### DIFF
--- a/src/main/scala/wolfendale/nunjucks/Context.scala
+++ b/src/main/scala/wolfendale/nunjucks/Context.scala
@@ -7,7 +7,6 @@ final case class Context(environment: Environment,
                          private val _frame: Frame = Frame.empty,
                          private val _variables: Map[String, Value] = Map.empty,
                          private val _blocks: Map[String, Vector[TemplateNode.Partial]] = Map.empty,
-                         private val _filters: Map[String, Filter] = wolfendale.nunjucks.filters.defaults,
                          private val _path: Option[String] = None) {
 
 
@@ -28,9 +27,6 @@ final case class Context(environment: Environment,
 
   def blocks: Context.BlockProjection =
     Context.BlockProjection(this)
-
-  def filters: Context.FilterProjection =
-    Context.FilterProjection(this)
 
   def path: Context.PathProjection =
     Context.PathProjection(this)
@@ -120,15 +116,6 @@ object Context {
 
     def push(key: String, block: TemplateNode.Partial): Context =
       context.copy(_blocks = context._blocks + (key -> (block +: get(key))))
-  }
-
-  final case class FilterProjection(context: Context) {
-
-    def get(key: String): Option[Filter] =
-      context._filters.get(key)
-
-    def set(key: String, filter: Filter): Context =
-      context.copy(_filters = context._filters + (key -> filter))
   }
 
   final case class PathProjection(context: Context) {

--- a/src/main/scala/wolfendale/nunjucks/Environment.scala
+++ b/src/main/scala/wolfendale/nunjucks/Environment.scala
@@ -5,10 +5,13 @@ import cats.data._
 import cats.implicits._
 import wolfendale.nunjucks.expression.runtime.Value
 
-class Environment(loaders: NonEmptyChain[Loader]) {
+class Environment(
+                   loaders: NonEmptyChain[Loader],
+                   filters: Map[String, Filter]
+                 ) {
 
   def this(loader: Loader, rest: Loader*) =
-    this(NonEmptyChain(loader, rest: _*))
+    this(NonEmptyChain(loader, rest: _*), wolfendale.nunjucks.filters.defaults)
 
   def resolveAndLoad(path: String, caller: Option[String]): Either[List[String], Loader.ResolvedTemplate] =
     loaders.parTraverse(_.resolveAndLoad(path, caller)).map(_.head)
@@ -35,6 +38,9 @@ class Environment(loaders: NonEmptyChain[Loader]) {
       .variables.set(scope.values.toSeq)
     parse(template, TemplateParser.template(_)).get.value.render.runA(context).value
   }
+
+  def getFilter(identifier: String): Option[Filter] =
+    filters.get(identifier)
 }
 
 final class ProvidedEnvironment(loader: ProvidedLoader = new ProvidedLoader()) extends Environment(loader) {

--- a/src/main/scala/wolfendale/nunjucks/TemplateNode.scala
+++ b/src/main/scala/wolfendale/nunjucks/TemplateNode.scala
@@ -467,8 +467,8 @@ object TemplateNode {
                        Value.Function.Parameter(k.map(_.value), v.eval.runA(context).value)
                    })
 
-                   context.filters
-                     .get(identifier.value)
+                   context.environment
+                     .getFilter(identifier.value)
                      .map(_.apply(context.frame.get, expression.runtime.Value.Str(content), parameters))
                      .getOrElse(throw new RuntimeException(s"No filter with name: ${identifier.value}"))
                      .toStr

--- a/src/main/scala/wolfendale/nunjucks/expression/syntax/AST.scala
+++ b/src/main/scala/wolfendale/nunjucks/expression/syntax/AST.scala
@@ -290,7 +290,8 @@ object AST {
         value  <- expr.eval
         params <- parameters
         result <- State.inspect[Context, Value] { context =>
-          context.filters.get(identifier.value)
+          context.environment
+            .getFilter(identifier.value)
             .map(_.apply(context.frame.get, value, params))
             .getOrElse(throw new RuntimeException(s"Filter not found: ${identifier.value}"))
         }


### PR DESCRIPTION
This allows adding custom filters to the environment when it's instantiated. It's crude but it's a good initial interface for adding custom filters.

This is also more like how nunjucks works.